### PR TITLE
ci: add GitHub Actions workflow to auto-deploy to gh-pages with custo…

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,32 @@
+name: Deploy to GitHub Pages
+
+on:
+    push:
+        branches:
+            - main
+
+jobs:
+    deploy:
+        runs-on: ubuntu-latest
+
+        steps:
+            - name: Checkout code
+              uses: actions/checkout@v3
+
+            - name: Set up Node.js
+              uses: actions/setup-node@v4
+              with:
+                  node-version: 18
+
+            - name: Install dependencies
+              run: yarn install --frozen-lockfile
+
+            - name: Build the React app
+              run: yarn build
+
+            - name: Deploy to gh-pages
+              uses: peaceiris/actions-gh-pages@v3
+              with:
+                  github_token: ${{ secrets.GITHUB_TOKEN }}
+                  publish_dir: ./build
+                  cname: eatsafe.fr


### PR DESCRIPTION
This pull request introduces a GitHub Actions workflow for deploying a React application to GitHub Pages. The workflow automates the process of building the app and publishing it to the `gh-pages` branch.

Deployment automation:

* [`.github/workflows/deploy.yml`](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3R1-R32): Added a new workflow named "Deploy to GitHub Pages" that triggers on pushes to the `main` branch. It includes steps for checking out the code, setting up Node.js, installing dependencies, building the React app, and deploying it to GitHub Pages using the `peaceiris/actions-gh-pages` action.…m domain