### PR TITLE
feat: delay map rendering until geolocation is resolved

### DIFF
--- a/src/components/Map/MapWrapper.tsx
+++ b/src/components/Map/MapWrapper.tsx
@@ -126,7 +126,7 @@ export default function MapWrapper() {
                 }
                 return;
             } else if (result.type === "city") {
-                const r = await getPlaceDetails(result.placeId);
+                const r = await getPlaceDetails(result.placeId!);
                 setMapCenter({ lat: r?.geometry?.location?.lat() || DEFAULT_CENTER.lat, lng: r?.geometry?.location?.lng() || DEFAULT_CENTER.lng });
                 if (mapRef.current) {
                     mapRef.current.panTo({ lat: r?.geometry?.location?.lat() || DEFAULT_CENTER.lat, lng: r?.geometry?.location?.lng() || DEFAULT_CENTER.lng });

--- a/src/components/Map/MapWrapper.tsx
+++ b/src/components/Map/MapWrapper.tsx
@@ -31,6 +31,7 @@ const DEFAULT_CENTER = { lat: 46.603354, lng: 1.888334 };
 const googleLibraries: ("places")[] = ["places"];
 
 export default function MapWrapper() {
+    const [isReady, setIsReady] = useState(false);
     const [mapCenter, setMapCenter] = useState(DEFAULT_CENTER);
     const [currentZoom, setCurrentZoom] = useState(6);
     const [searching, setSearching] = useState(false);
@@ -56,8 +57,14 @@ export default function MapWrapper() {
 
     useEffect(() => {
         navigator.geolocation.getCurrentPosition(
-            ({ coords }) => setMapCenter({ lat: coords.latitude, lng: coords.longitude }),
-            () => setMapCenter(DEFAULT_CENTER)
+            ({ coords }) => {
+                setMapCenter({ lat: Number(coords.latitude), lng: Number(coords.longitude) });
+                setIsReady(true);
+            },
+            () => {
+                setMapCenter(DEFAULT_CENTER);
+                setIsReady(true);
+            }
         );
     }, []);
 
@@ -240,19 +247,21 @@ export default function MapWrapper() {
                 onSearch={handleFilterSearch}
             />
 
-            <GoogleMap
-                mapContainerStyle={containerStyle}
-                center={mapCenter}
-                zoom={6}
-                onLoad={onMapLoad}
-                options={{
-                    disableDefaultUI: true,
-                    zoomControl: false,
-                    mapTypeControl: false,
-                    streetViewControl: false,
-                    fullscreenControl: false,
-                }}
-            />
+            {isReady && (
+                <GoogleMap
+                    mapContainerStyle={containerStyle}
+                    center={mapCenter}
+                    zoom={6}
+                    onLoad={onMapLoad}
+                    options={{
+                        disableDefaultUI: true,
+                        zoomControl: false,
+                        mapTypeControl: false,
+                        streetViewControl: false,
+                        fullscreenControl: false,
+                    }}
+                />
+            )}
 
             {selectedRestaurant && (
                 <RestaurantCard
@@ -263,7 +272,7 @@ export default function MapWrapper() {
                 />
             )}
 
-            {searching && <OverlaySpinner />}
+            {(searching && isReady) && <OverlaySpinner />}
         </LoadScript>
     );
 }

--- a/src/components/Map/MapWrapper.tsx
+++ b/src/components/Map/MapWrapper.tsx
@@ -126,11 +126,24 @@ export default function MapWrapper() {
                 }
                 return;
             } else if (result.type === "city") {
-                const r = await getPlaceDetails(result.placeId!);
-                setMapCenter({ lat: r?.geometry?.location?.lat() || DEFAULT_CENTER.lat, lng: r?.geometry?.location?.lng() || DEFAULT_CENTER.lng });
+                setSelectedRestaurant(null);
+                clearMarkers();
+
+                const place = await getPlaceDetails(result.placeId!);
+                const location = place?.geometry?.location;
+                const lat = location?.lat() ?? DEFAULT_CENTER.lat;
+                const lng = location?.lng() ?? DEFAULT_CENTER.lng;
+
+                setMapCenter({ lat, lng });
                 if (mapRef.current) {
-                    mapRef.current.panTo({ lat: r?.geometry?.location?.lat() || DEFAULT_CENTER.lat, lng: r?.geometry?.location?.lng() || DEFAULT_CENTER.lng });
+                    mapRef.current.panTo({ lat, lng });
                     mapRef.current.setZoom(14);
+                }
+
+                const restaurants = await fetchFilteredRestaurants({ city: result.city });
+
+                if (restaurants.length && mapRef.current) {
+                    createNativeMarkers(mapRef.current, restaurants);
                 }
             }
         } catch {

--- a/src/components/UI/SearchBar/ContactModal.tsx
+++ b/src/components/UI/SearchBar/ContactModal.tsx
@@ -6,10 +6,9 @@ import {
     DialogActions,
     TextField,
     Button,
-    Snackbar,
-    Alert,
 } from "@mui/material";
 import { sendContactMessage } from "@services/contactService";
+import Toast from "@components/UI/Toast/Toast";
 
 interface Props {
     open: boolean;
@@ -101,13 +100,12 @@ export default function ContactModal({ open, onClose }: Props) {
             </DialogActions>
         </Dialog>
 
-        <Snackbar
+        <Toast
             open={success}
-            autoHideDuration={4000}
+            message={"Message envoyé avec succès"}
+            severity="success"
             onClose={() => setSuccess(false)}
-        >
-            <Alert severity="success">Message envoyé avec succès</Alert>
-        </Snackbar>
+        />
         </>
     );
 }

--- a/src/components/UI/SearchBar/SearchBar.tsx
+++ b/src/components/UI/SearchBar/SearchBar.tsx
@@ -27,7 +27,7 @@ const SearchBar = ({ onSearch }: Props) => {
                 label: `${p.description}`,
                 placeId: p.place_id,
                 name: namePart.trim(),
-                city: rest.join(",").trim(),
+                city: namePart.trim(),
             };
         });
 

--- a/src/components/UI/SearchBar/SearchBar.tsx
+++ b/src/components/UI/SearchBar/SearchBar.tsx
@@ -2,18 +2,7 @@ import { useEffect, useState, useMemo, useCallback } from "react";
 import { Autocomplete, Box, TextField } from "@mui/material";
 import debounce from "lodash.debounce";
 import { useAutocompleteService } from "@hooks/useAutoCompleteService";
-
-interface Props {
-    onSearch: (name: string, city: string) => void;
-}
-
-interface Option {
-    type: "google";
-    label: string;
-    placeId: string;
-    name: string;
-    city: string;
-}
+import { Props, Option} from "@/types/search";
 
 const SearchBar = ({ onSearch }: Props) => {
     const [inputValue, setInputValue] = useState("");
@@ -22,17 +11,19 @@ const SearchBar = ({ onSearch }: Props) => {
 
     const handleSearch = useCallback(async (value: string) => {
         const googleResults = await getPredictions(value);
+
         const formatted: Option[] = googleResults.map((p) => {
             const [namePart, ...rest] = p.description.split(",");
             return {
-                type: "google",
+                type: "city",
                 label: p.description,
                 placeId: p.place_id,
                 name: namePart.trim(),
                 city: rest.join(",").trim(),
             };
         });
-        setOptions(formatted);
+
+        setOptions([...formatted]);
     }, [getPredictions]);
 
     const debouncedSearch = useMemo(
@@ -65,9 +56,7 @@ const SearchBar = ({ onSearch }: Props) => {
                 onInputChange={(_, value) => setInputValue(value)}
                 onChange={(_, value) => {
                     if (!value || typeof value === "string") return;
-                    if (value.type === "google") {
-                        onSearch(value.name, value.city);
-                    }
+                    onSearch(value);
                 }}
                 renderInput={(params) => (
                     <TextField

--- a/src/components/UI/Toast/Toast.tsx
+++ b/src/components/UI/Toast/Toast.tsx
@@ -1,0 +1,30 @@
+import { Snackbar, Alert } from "@mui/material";
+
+type ToastProps = {
+    open: boolean;
+    message: string;
+    severity?: "error" | "warning" | "info" | "success";
+    onClose: () => void;
+    duration?: number;
+};
+
+export default function Toast({
+    open,
+    message,
+    severity = "info",
+    onClose,
+    duration = 5000,
+}: ToastProps) {
+    return (
+        <Snackbar
+            open={open}
+            autoHideDuration={duration}
+            onClose={onClose}
+            anchorOrigin={{ vertical: "top", horizontal: "center" }}
+        >
+            <Alert onClose={onClose} severity={severity} sx={{ width: "100%" }}>
+                {message}
+            </Alert>
+        </Snackbar>
+    );
+}

--- a/src/hooks/useAutoCompleteService.ts
+++ b/src/hooks/useAutoCompleteService.ts
@@ -13,7 +13,7 @@ export const useAutocompleteService = () => {
         return new Promise((resolve, reject) => {
             if (!serviceRef.current || !input) return resolve([]);
             serviceRef.current.getPlacePredictions(
-                { input, componentRestrictions: { country: "fr" } },
+                { input, types: ["(cities)"], componentRestrictions: { country: "fr" } },
                 (predictions, status) => {
                     if (status !== "OK" || !predictions) return resolve([]);
                     resolve(predictions);

--- a/src/hooks/usePlaceDetails.ts
+++ b/src/hooks/usePlaceDetails.ts
@@ -1,86 +1,20 @@
-import { useRef } from "react";
-
 export const usePlaceDetails = () => {
-    const serviceRef = useRef<google.maps.places.PlacesService | null>(null);
-
-    const setMapElement = (map: google.maps.Map) => {
-        serviceRef.current = new google.maps.places.PlacesService(map);
-    };
-
     const getPlaceDetails = (placeId: string): Promise<google.maps.places.PlaceResult | null> => {
-        return new Promise((resolve) => {
-            if (!serviceRef.current) return resolve(null);
-
-            serviceRef.current.getDetails(
-                {
-                    placeId,
-                    fields: [
-                        "name",
-                        "geometry",
-                        "rating",
-                        "formatted_address",
-                        "photos",
-                        "types",
-                        "place_id",
-                        "reviews",
-                        "user_ratings_total",
-                        "opening_hours",
-                        "price_level",
-                    ],
-                    language: "fr",
-                    region: "fr"
-                },
-                (place, status) => {
-                    if (status !== google.maps.places.PlacesServiceStatus.OK || !place) {
-                        return resolve(null);
-                    }
+        return new Promise((resolve, reject) => {
+            const service = new google.maps.places.PlacesService(document.createElement("div"));
+            service.getDetails({ placeId }, (place, status) => {
+                if (status === google.maps.places.PlacesServiceStatus.OK && place) {
                     resolve(place);
+                } else {
+                    console.error("Place details error:", status);
+                    resolve(null);
                 }
-            );
+            });
         });
     };
 
-    const getPlaceDetailsByTextSearch = (
-        query: string,
-        lat: number,
-        lng: number,
-        city: string
-    ): Promise<google.maps.places.PlaceResult | null> => {
-        return new Promise((resolve) => {
-            const textService = new google.maps.places.PlacesService(document.createElement("div"));
-
-            textService.textSearch(
-                {
-                    query,
-                    location: new google.maps.LatLng(lat, lng),
-                    radius: 300,
-                    type: "restaurant",
-                },
-                (results, status) => {
-                    if (
-                        status === google.maps.places.PlacesServiceStatus.OK &&
-                        results &&
-                        results.length > 0
-                    ) {
-                        const restaurant = results.find(
-                            (r) =>
-                                r.types?.includes("restaurant") &&
-                                r.formatted_address?.toLowerCase().includes(city.toLowerCase())
-                            );
-                            if (!restaurant?.place_id) return resolve(null);
-
-                            getPlaceDetails(restaurant.place_id).then(resolve).catch(() => resolve(null));
-                    } else {
-                        resolve(null);
-                    }
-                }
-            );
-        });
-    };
 
     return {
-        setMapElement,
         getPlaceDetails,
-        getPlaceDetailsByTextSearch
     };
 };

--- a/src/services/restaurantService.ts
+++ b/src/services/restaurantService.ts
@@ -9,6 +9,13 @@ export const fetchFilterData = async (): Promise<RestaurantFilterValues> => {
     return res.data;
 };
 
+export const searchRestaurants = async (query: string): Promise<Restaurant[]> => {
+    const res = await axios.get<Restaurant[]>("/restaurants/search", {
+        params: { q: query }
+    });
+    return res.data;
+};
+
 export const fetchFilteredRestaurants = async (
     filters: FilterValues
 ): Promise<Restaurant[]> => {

--- a/src/types/search.ts
+++ b/src/types/search.ts
@@ -1,0 +1,13 @@
+export interface Props {
+    onSearch: (value: Option) => void;
+}
+
+export interface Option {
+    type: "restaurant" | "city";
+    label: string;
+    placeId: string;
+    name: string;
+    city: string;
+    lng?: number;
+    lat?: number;
+}

--- a/src/types/search.ts
+++ b/src/types/search.ts
@@ -5,7 +5,7 @@ export interface Props {
 export interface Option {
     type: "restaurant" | "city";
     label: string;
-    placeId: string;
+    placeId?: string;
     name: string;
     city: string;
     lng?: number;

--- a/src/utils/format.ts
+++ b/src/utils/format.ts
@@ -57,3 +57,11 @@ export function extractCity(city: string): string {
     }
     return city.trim().split(" ")[0];
 }
+
+export const toTitleCase = (str: string): string => {
+    return str
+        .toLowerCase()
+        .split(" ")
+        .map(word => word.charAt(0).toUpperCase() + word.slice(1))
+        .join(" ");
+};


### PR DESCRIPTION
This pull request introduces changes to the `MapWrapper` component in `src/components/Map/MapWrapper.tsx` to improve the handling of map readiness and ensure smoother user experience during initialization. The most important changes include adding an `isReady` state to track map readiness, updating the geolocation logic to set this state, and conditionally rendering map elements based on readiness.

### Improvements to map readiness handling:

* **Added `isReady` state**: Introduced a new `isReady` state using `useState` to track when the map is ready for interaction. (`[src/components/Map/MapWrapper.tsxR34](diffhunk://#diff-b819205adc83659d55534f29208950861f27601565b2b684d5452ef98ae4c595R34)`)

* **Updated geolocation logic**: Modified the `navigator.geolocation.getCurrentPosition` callback to set `isReady` to `true` once the map center is determined, ensuring readiness is explicitly tracked. (`[src/components/Map/MapWrapper.tsxL59-R67](diffhunk://#diff-b819205adc83659d55534f29208950861f27601565b2b684d5452ef98ae4c595L59-R67)`)

### Conditional rendering based on readiness:

* **Conditional rendering of `GoogleMap`**: Wrapped the `GoogleMap` component in a conditional block to render it only when `isReady` is `true`, preventing premature rendering. (`[[1]](diffhunk://#diff-b819205adc83659d55534f29208950861f27601565b2b684d5452ef98ae4c595R250)`, `[[2]](diffhunk://#diff-b819205adc83659d55534f29208950861f27601565b2b684d5452ef98ae4c595R264)`)

* **Updated `OverlaySpinner` rendering**: Adjusted the rendering logic for the `OverlaySpinner` component to display it only when both `searching` and `isReady` are `true`, improving user feedback during loading. (`[src/components/Map/MapWrapper.tsxL266-R275](diffhunk://#diff-b819205adc83659d55534f29208950861f27601565b2b684d5452ef98ae4c595L266-R275)`)